### PR TITLE
fix the endpoint change buggy

### DIFF
--- a/src/components/EndpointInfo.tsx
+++ b/src/components/EndpointInfo.tsx
@@ -131,21 +131,22 @@ export default function ConnectionDetailModal() {
             <VStack>
               <FormControl isInvalid={machine.value === 'error'}>
                 <EndpointAddressInput label="RPC Endpoint" />
-                {
-                  machine.value !== 'error' ? 
-                  <>
-                    <SuspenseFormField label="Cluster ID">
-                      <ClusterIdSelect />
-                    </SuspenseFormField>
-                    <SuspenseFormField label="Worker">
-                      <WorkerSelect />
-                    </SuspenseFormField>
-                    <SuspenseFormField label="PRuntime">
-                      <PruntimeEndpointSelect />
-                    </SuspenseFormField>
-                  </> : <FormErrorMessage>Connect error: the RPC Endpoint is wrong.</FormErrorMessage>
-                }
+                <FormErrorMessage>Connect error: the RPC Endpoint is wrong.</FormErrorMessage>
               </FormControl>
+              {
+                 machine.value !== 'error' ? 
+                 <>
+                   <SuspenseFormField label="Cluster ID">
+                     <ClusterIdSelect />
+                   </SuspenseFormField>
+                   <SuspenseFormField label="Worker">
+                     <WorkerSelect />
+                   </SuspenseFormField>
+                   <SuspenseFormField label="PRuntime">
+                     <PruntimeEndpointSelect />
+                   </SuspenseFormField>
+                 </> : null
+              }
             </VStack>
           </ModalBody>
         <ModalFooter></ModalFooter>

--- a/src/components/EndpointInfo.tsx
+++ b/src/components/EndpointInfo.tsx
@@ -119,7 +119,7 @@ const PruntimeEndpointSelect = () => {
 
 export default function ConnectionDetailModal() {
   const [visible, setVisible] = useAtom(connectionDetailModalVisibleAtom)
-  const [machine] = useAtom(websocketConnectionMachineAtom)
+  const machine = useAtomValue(websocketConnectionMachineAtom)
   
   return (
     <Modal isOpen={visible} onClose={() => setVisible(false)}>

--- a/src/components/EndpointInfo.tsx
+++ b/src/components/EndpointInfo.tsx
@@ -21,6 +21,7 @@ import {
   InputGroup,
   Button,
   ButtonGroup,
+  FormErrorMessage,
 } from '@chakra-ui/react'
 import { atom, useAtomValue, useAtom } from 'jotai'
 
@@ -34,6 +35,7 @@ import {
   availableWorkerListAtom,
   availablePruntimeListAtom,
 } from '@/features/phat-contract/atoms'
+import { websocketConnectionMachineAtom } from '@/features/parachain/atoms'
 
 export const connectionDetailModalVisibleAtom = atom(false)
 
@@ -117,6 +119,8 @@ const PruntimeEndpointSelect = () => {
 
 export default function ConnectionDetailModal() {
   const [visible, setVisible] = useAtom(connectionDetailModalVisibleAtom)
+  const [machine] = useAtom(websocketConnectionMachineAtom)
+  
   return (
     <Modal isOpen={visible} onClose={() => setVisible(false)}>
       <ModalOverlay />
@@ -125,16 +129,23 @@ export default function ConnectionDetailModal() {
         <ModalCloseButton />
           <ModalBody>
             <VStack>
-              <EndpointAddressInput label="RPC Endpoint" />
-              <SuspenseFormField label="Cluster ID">
-                <ClusterIdSelect />
-              </SuspenseFormField>
-              <SuspenseFormField label="Worker">
-                <WorkerSelect />
-              </SuspenseFormField>
-              <SuspenseFormField label="PRuntime">
-                <PruntimeEndpointSelect />
-              </SuspenseFormField>
+              <FormControl isInvalid={machine.value === 'error'}>
+                <EndpointAddressInput label="RPC Endpoint" />
+                {
+                  machine.value !== 'error' ? 
+                  <>
+                    <SuspenseFormField label="Cluster ID">
+                      <ClusterIdSelect />
+                    </SuspenseFormField>
+                    <SuspenseFormField label="Worker">
+                      <WorkerSelect />
+                    </SuspenseFormField>
+                    <SuspenseFormField label="PRuntime">
+                      <PruntimeEndpointSelect />
+                    </SuspenseFormField>
+                  </> : <FormErrorMessage>Connect error: the RPC Endpoint is wrong.</FormErrorMessage>
+                }
+              </FormControl>
             </VStack>
           </ModalBody>
         <ModalFooter></ModalFooter>

--- a/src/features/parachain/atoms.ts
+++ b/src/features/parachain/atoms.ts
@@ -51,6 +51,13 @@ export const websocketConnectionMachineAtom = atomWithMachine<WebsocketConnectio
               debug('setStatus -> error')
 
               ws.disconnect();
+
+              send({
+                type: 'CONNECT_FAILED',
+                data: {
+                  endpoint: ctx.endpoint,
+                }
+              })
             })
 
             const api = await createApiPromise(ws);

--- a/src/features/parachain/websocketConnectionMachine.ts
+++ b/src/features/parachain/websocketConnectionMachine.ts
@@ -84,6 +84,14 @@ export function createWebsocketConnectionMachineConfig(ctx: WebsocketConnectionC
         },
       }, // END: disconnected
 
+      error: {
+        on: {
+          CONNECT: {
+            target: 'connecting'
+          }
+        }
+      },
+
       connecting: {
         invoke: {
           id: 'connecting',
@@ -97,7 +105,7 @@ export function createWebsocketConnectionMachineConfig(ctx: WebsocketConnectionC
             ]
           },
           CONNECT_TIMEOUT: {
-            target: 'disconnected',
+            target: 'error',
             actions: [
               'setError',
             ],
@@ -147,7 +155,7 @@ export function createWebsocketConnectionMachineConfig(ctx: WebsocketConnectionC
             target: 'disconnecting',
           },
           CONNECT_FAILED: {
-            target: 'disconnected',
+            target: 'error',
             actions: [
               'setError',
             ],


### PR DESCRIPTION
When user type an invalid endpoint URL, they can't change it until reload the page.