### PR TITLE
Ink4 metadata supports

### DIFF
--- a/@types/contract.d.ts
+++ b/@types/contract.d.ts
@@ -70,7 +70,7 @@ type ContractMetadata = {
     version: string;
     authors: string[];
   },
-  V3: {
+  V3?: {
     spec: {
       constructors: ContractMetaConstructor[];
       docs: string[];
@@ -80,4 +80,12 @@ type ContractMetadata = {
     storage: ContractMetaStorage,
     types: ContractMetaType[],
   }
+  spec: {
+    constructors: ContractMetaConstructor[];
+    docs: string[];
+    events: unknown[];
+    messages: ContractMetaMessage[];
+  },
+  storage: ContractMetaStorage,
+  types: ContractMetaType[],
 }

--- a/src/features/phat-contract/atoms.ts
+++ b/src/features/phat-contract/atoms.ts
@@ -55,7 +55,8 @@ export const contractAvailableSelectorAtom = atom(get => {
   if (!contract) {
     return []
   }
-  return [...contract.V3.spec.constructors.map(i => ({
+  const spec = contract.V3 ? contract.V3.spec : contract.spec
+  return [...spec.constructors.map(i => ({
     value: i.selector,
     label: i.label,
     default: i.label === 'default',
@@ -373,7 +374,10 @@ export const messagesAtom = atom(get => {
   if (!contract) {
     return []
   }
-  return contract.metadata.V3.spec.messages || []
+  if (contract.metadata.V3) {
+    return contract.metadata.V3.spec.messages || []
+  }
+  return contract.metadata.spec.messages || []
 })
 
 export const phalaFatContractQueryAtom = atom(async get => {

--- a/src/features/phat-contract/atoms.ts
+++ b/src/features/phat-contract/atoms.ts
@@ -112,8 +112,11 @@ export const contractCandidateAtom = atom('', (get, set, fileInfo: FileInfo) => 
         set(contractParserErrorAtom, "Your contract file is invalid.")
         return
       }
-      if (!contract.V3) {
-        set(contractParserErrorAtom, "Your contract metadata version is too low, Please upgrade your cargo-contract with `cargo install cargo-contract --force`.")
+
+      try {
+        new Abi(contract)
+      } catch (err) {
+        set(contractParserErrorAtom, `Your contract file is invalid: ${err}`)
         return
       }
 

--- a/src/features/phat-contract/hooks/useLocalContractsImport.ts
+++ b/src/features/phat-contract/hooks/useLocalContractsImport.ts
@@ -20,11 +20,6 @@ export default function useLocalContractsImport() {
             console.log('import error: Your contract file is invalid')
             return
           }
-          if (!contract.V3) {
-            console.log('import error: Your contract metadata version is too low, Please upgrade your cargo-contract with `cargo install cargo-contract --force`.')
-            // set(contractParserErrorAtom, "Your contract metadata version is too low, Please upgrade your cargo-contract with `cargo install cargo-contract --force`.")
-            return
-          }
           if (!contract.phat || !contract.phat.contractId) {
             console.log('import error: For now only support metadata that export from contract UI.')
             // set(contractParserErrorAtom, "Your contract metadata version is too low, Please upgrade your cargo-contract with `cargo install cargo-contract --force`.")

--- a/src/features/phat-contract/hooks/useUploadCodeAndInstantiate.ts
+++ b/src/features/phat-contract/hooks/useUploadCodeAndInstantiate.ts
@@ -40,7 +40,8 @@ export default function useUploadCodeAndInstantiate() {
   
       const salt = '0x' + new Date().getTime()
 
-      if (contract.V3.spec.constructors.length === 0) {
+      const spec = contract.V3 ? contract.V3.spec : contract.spec
+      if (spec.constructors.length === 0) {
         throw new Error('No constructor found.')
       }
       const defaultInitSelector = R.pipe(
@@ -48,7 +49,7 @@ export default function useUploadCodeAndInstantiate() {
         R.sortBy((c: ContractMetaConstructor) => c.args.length),
         i => R.head<ContractMetaConstructor>(i),
         (i) => i ? i.selector : undefined,
-      )(contract.V3.spec.constructors)
+      )(spec.constructors)
 
       const initSelector = chooseInitSelector || defaultInitSelector
       console.log('user choose initSelector: ', chooseInitSelector)


### PR DESCRIPTION
This PR aims to add support for Ink V4 metadata while maintaining support for Ink V3. This is because not all testnets have been upgraded to support V4 yet.

This should resolve the issue described here: https://substrate.stackexchange.com/q/7699/3979