### PR TITLE
Use string input for fixed length Vec

### DIFF
--- a/src/features/phat-contract/argumentsFormAtom.ts
+++ b/src/features/phat-contract/argumentsFormAtom.ts
@@ -395,10 +395,16 @@ export const currentArgsFormAtom = atom(get => get(get(currentArgsFormAtomInAtom
   const currentArgsFormAtom = get(currentArgsFormAtomInAtom)
   set(currentArgsFormAtom, update)
 })
+
 export const currentFieldDataSetReadOnlyAtom = selectAtom(currentArgsFormAtom, form => form.fieldDataSet)
 
 export const getFieldValue = (fieldDataSet: FieldDataSet, uid: string): unknown => {
   const fieldData = fieldDataSet[uid]
+
+  if (fieldData.typeDef.type === '[u8;32]') {
+    return fieldData.value
+  }
+
   const { typeDef: { info }, value } = fieldData
 
   if (HAS_SUB_FIELD_DATA_TYPE.indexOf(info) > -1) {
@@ -436,6 +442,11 @@ export const getFormValue = (form: FormNormalized) => {
 
 export const collectRelativeUidList = (fieldDataSet: FieldDataSet, uid: string): string[] => {
   const fieldData = fieldDataSet[uid]
+
+  if (fieldData.typeDef.type === '[u8;32]') {
+    return [uid]
+  }
+
   const { typeDef: { info }, value } = fieldData
   const uidList = [uid]
   let subUidList: string[] = []

--- a/src/features/phat-contract/argumentsFormAtom.ts
+++ b/src/features/phat-contract/argumentsFormAtom.ts
@@ -401,7 +401,8 @@ export const currentFieldDataSetReadOnlyAtom = selectAtom(currentArgsFormAtom, f
 export const getFieldValue = (fieldDataSet: FieldDataSet, uid: string): unknown => {
   const fieldData = fieldDataSet[uid]
 
-  if (fieldData.typeDef.type === '[u8;32]') {
+  // [u8;32] or [u8;29]
+  if (fieldData.typeDef.type.indexOf('[u8;') === 0) {
     return fieldData.value
   }
 
@@ -443,7 +444,8 @@ export const getFormValue = (form: FormNormalized) => {
 export const collectRelativeUidList = (fieldDataSet: FieldDataSet, uid: string): string[] => {
   const fieldData = fieldDataSet[uid]
 
-  if (fieldData.typeDef.type === '[u8;32]') {
+  // [u8;32] or [u8;29]
+  if (fieldData.typeDef.type.indexOf('[u8;') === 0) {
     return [uid]
   }
 

--- a/src/features/phat-contract/components/contract-method-arguments-form.tsx
+++ b/src/features/phat-contract/components/contract-method-arguments-form.tsx
@@ -490,6 +490,9 @@ const ArgumentFieldData = ({ uid, dispatch }: FieldDataProps) => {
       return <TupleOrVecFixedTypeFieldData fieldData={fieldData} dispatch={dispatch} />
 
     case TypeDefInfo.VecFixed:
+      if (fieldData.typeDef.type === '[u8;32]') {
+        return <PlainTypeFieldData fieldData={fieldData} dispatch={dispatch} />
+      }
       return <TupleOrVecFixedTypeFieldData fieldData={fieldData} dispatch={dispatch} />
 
     case TypeDefInfo.Vec:

--- a/src/features/phat-contract/components/contract-method-arguments-form.tsx
+++ b/src/features/phat-contract/components/contract-method-arguments-form.tsx
@@ -490,7 +490,8 @@ const ArgumentFieldData = ({ uid, dispatch }: FieldDataProps) => {
       return <TupleOrVecFixedTypeFieldData fieldData={fieldData} dispatch={dispatch} />
 
     case TypeDefInfo.VecFixed:
-      if (fieldData.typeDef.type === '[u8;32]') {
+      // [u8;32] or [u8;29]
+      if (fieldData.typeDef.type.indexOf('[u8;') === 0) {
         return <PlainTypeFieldData fieldData={fieldData} dispatch={dispatch} />
       }
       return <TupleOrVecFixedTypeFieldData fieldData={fieldData} dispatch={dispatch} />

--- a/src/features/phat-contract/hooks/useContractExecutor.ts
+++ b/src/features/phat-contract/hooks/useContractExecutor.ts
@@ -212,8 +212,11 @@ export default function useContractExecutor(): [boolean, (depositSettings: Depos
         return
       }
       const args = R.map(
-        i => {
-          const value = inputValues[i.label]
+        arg => {
+          const value = inputValues[arg.label]
+          if (R.path(['type', 'displayName', '0'], arg) === 'String') {
+            return api.createType('String', value)
+          }
           return value
         },
         methodSpec.args


### PR DESCRIPTION
As suggested by @tolak, we can improve the user experience for `[u8; 32]` (and also `[u8; 20]`) by using a single input instead of a list of numbers.