### PR TITLE
fix: use api.createType bypass the polkadot api builtin type auto selection

### DIFF
--- a/src/features/phat-contract/hooks/useContractExecutor.ts
+++ b/src/features/phat-contract/hooks/useContractExecutor.ts
@@ -34,9 +34,7 @@ import {
   currentSystemContractIdAtom,
   currentWorkerIdAtom,
 } from '../atoms'
-import { singleInputsValidator } from '@/functions/argumentsValidator'
-import { currentArgsFormAtomInAtom, FormActionType, formReducer, getCheckedForm, getFieldValue, getFormIsInvalid, getFormValue } from '../argumentsFormAtom'
-// import { currentArgsFormErrorsOfAtom, currentArgsFormValidateAtom, currentArgsFormValueOfAtom } from '../argumentsFormAtom'
+import { currentArgsFormAtomInAtom, FormActionType, formReducer, getCheckedForm, getFormIsInvalid, getFormValue } from '../argumentsFormAtom'
 
 
 interface InkResponse {

--- a/src/features/phat-contract/hooks/useContractExecutor.ts
+++ b/src/features/phat-contract/hooks/useContractExecutor.ts
@@ -212,9 +212,15 @@ export default function useContractExecutor(): [boolean, (depositSettings: Depos
         return
       }
       const abiArgs = R.find(i => i.identifier === methodSpec.label, contractInstance.abi.messages)
+      debug('parsed abi args:', abiArgs)
       const args = R.map(
         ([arg, abiArg]) => {
           const value = inputValues[arg.label]
+          // If type is Text, input like `0x02` might auto conhort to hex string at polkadot-js internal,
+          // so we need to convert it to hex string to bypass that.
+          if (abiArg.type.type === 'Text') {
+            return api.createType('Text', stringToHex(value as string))
+          }
           return api.createType(abiArg.type.type, value)
         },
         R.zip(methodSpec.args, abiArgs!.args)

--- a/src/features/phat-contract/hooks/useContractExecutor.ts
+++ b/src/features/phat-contract/hooks/useContractExecutor.ts
@@ -211,15 +211,13 @@ export default function useContractExecutor(): [boolean, (depositSettings: Depos
         debug('method not found', methodSpec.label)
         return
       }
+      const abiArgs = R.find(i => i.identifier === methodSpec.label, contractInstance.abi.messages)
       const args = R.map(
-        arg => {
+        ([arg, abiArg]) => {
           const value = inputValues[arg.label]
-          if (R.path(['type', 'displayName', '0'], arg) === 'String') {
-            return api.createType('String', value)
-          }
-          return value
+          return api.createType(abiArg.type.type, value)
         },
-        methodSpec.args
+        R.zip(methodSpec.args, abiArgs!.args)
       )
       debug('args built: ', args)
 

--- a/src/features/phat-contract/hooks/useContractExecutor.ts
+++ b/src/features/phat-contract/hooks/useContractExecutor.ts
@@ -216,10 +216,11 @@ export default function useContractExecutor(): [boolean, (depositSettings: Depos
       const args = R.map(
         ([arg, abiArg]) => {
           const value = inputValues[arg.label]
-          // If type is Text, input like `0x02` might auto conhort to hex string at polkadot-js internal,
-          // so we need to convert it to hex string to bypass that.
+          // Because the Text will try convert string prefix with `0x` to hex string, so we need to
+          // find a way to bypass that.
+          // @see: https://github.com/polkadot-js/api/blob/3d2307f12a7b82abcffb7dbcaac4a6ec6f9fee9d/packages/types-codec/src/native/Text.ts#L36
           if (abiArg.type.type === 'Text') {
-            return api.createType('Text', stringToHex(value as string))
+            return api.createType('Text', { toString: () => (value as string) })
           }
           return api.createType(abiArg.type.type, value)
         },

--- a/src/features/phat-contract/hooks/useContractExecutor.ts
+++ b/src/features/phat-contract/hooks/useContractExecutor.ts
@@ -229,7 +229,7 @@ export default function useContractExecutor(): [boolean, (depositSettings: Depos
         // const { signer } = await web3FromSource(account.meta.source)
         let txConf
         if (depositSettings.autoDeposit) {
-          txConf = await estimateGas(contractInstance, txMethods[methodSpec.label], cert, args);
+          txConf = await estimateGas(contractInstance, txMethods[methodSpec.label], cert, args as unknown[]);
           debug('auto deposit: ', txConf)
         } else {
           txConf = R.pick(['gasLimit', 'storageDepositLimit'], depositSettings)


### PR DESCRIPTION
If the user enters `0x01` as a `String` in the front-end form, it is unexpected that the back-end contract will receive `Hex`.

FIXME: We try to address this issue but the `createType` but we can find the right type name for `createType`.