### PR TITLE
the storage deposite fee estimation incorrect.

### DIFF
--- a/src/features/phat-contract/components/fat-contract-upload-form.tsx
+++ b/src/features/phat-contract/components/fat-contract-upload-form.tsx
@@ -390,12 +390,12 @@ function ClusterBalance() {
 
 const uploadCodeCheckAtom = atom(get => {
   const registry = get(phatRegistryAtom)
-  const finfo = get(candidateFileInfoAtom)
+  const candidate = get(candidateAtom)
   const currentBalance = get(currentBalanceAtom)
-  const storageDepositeFee = estimateDepositeFee(finfo.size, registry.clusterInfo?.depositPerByte)
-  if (!finfo.size) {
+  if (!candidate || !candidate.source || !candidate.source.wasm || !registry.clusterInfo) {
     return { canUpload: false, showTransferToCluster: false }
   }
+  const storageDepositeFee = estimateDepositeFee(candidate.source.wasm.length, registry.clusterInfo.depositPerByte)
   if (currentBalance < storageDepositeFee) {
     return { canUpload: false, showTransferToCluster: true, storageDepositeFee }
   }
@@ -586,7 +586,6 @@ function InstantiateGasElimiation() {
   const [, cert] = useAtomValue(cachedCertAtom)
   const signer = useAtomValue(signerAtom)
   const registry = useAtomValue(phatRegistryAtom)
-  const finfo = useAtomValue(candidateFileInfoAtom)
 
   const [txOptions, setTxOptions] = useState<any>(null)
   const [minClusterBalance, setMinClusterBalance] = useState(0)

--- a/src/features/phat-contract/components/fat-contract-upload-form.tsx
+++ b/src/features/phat-contract/components/fat-contract-upload-form.tsx
@@ -604,14 +604,13 @@ function InstantiateGasElimiation() {
           setTxOptions(null)
           // @ts-ignore
           const { gasRequired, storageDeposit, salt } = await blueprint.query[constructor](currentAccount.address, { cert }, ...args) // Support instantiate arguments.
-          const gasLimit = new Decimal(gasRequired.refTime.toNumber()).div(new Decimal(registry.clusterInfo?.gasPrice?.toNumber() || 1)).div(1e12)
-          const storageDepositeFee = estimateDepositeFee(finfo.size, registry.clusterInfo?.depositPerByte)
+          const gasLimit = new Decimal(gasRequired.refTime.toNumber()).mul(new Decimal(registry.clusterInfo?.gasPrice?.toNumber() || 1)).div(1e12)
           setTxOptions({
             gasLimit: gasRequired.refTime,
             storageDepositLimit: storageDeposit.isCharge ? storageDeposit.asCharge : null,
             salt
           })
-          setMinClusterBalance(gasLimit.plus(storageDepositeFee).toNumber())
+          setMinClusterBalance(gasLimit.toNumber())
           await refreshBalance()
         } finally {
           setIsLoading(false)


### PR DESCRIPTION
This PR proposes to fix the issue of incorrect storage deposit fee estimation, and also do `code_exists` check before upload, so we can skip upload (bypass unnecessary network round-trip since the storage deposit fee won't be paid twice, and the code already in the cluster)  and told user it can instantiate immediately.