### PR TITLE
Add upload status to file info and display success message

### DIFF
--- a/src/features/phat-contract/atoms.ts
+++ b/src/features/phat-contract/atoms.ts
@@ -49,7 +49,7 @@ export interface ContractExecuteResult {
 
 export const candidateAtom = atom<ContractMetadata | null>(null)
 
-export const candidateFileInfoAtom = atomWithReset({ name: '', size: 0 })
+export const candidateFileInfoAtom = atomWithReset({ name: '', size: 0, uploaded: false })
 export const candidateAllowIndeterminismAtom = atomWithReset(false)
 
 export const contractParserErrorAtom = atom('')
@@ -143,7 +143,7 @@ export const contractCandidateAtom = atom('', (get, set, fileInfo: FileInfo) => 
         }
       }
 
-      set(candidateFileInfoAtom, { name: file.name, size: file.size })
+      set(candidateFileInfoAtom, { name: file.name, size: file.size, uploaded: false })
       set(candidateAtom, contract)
     } catch (e) {
       console.error(e)

--- a/src/features/phat-contract/components/contract-upload.tsx
+++ b/src/features/phat-contract/components/contract-upload.tsx
@@ -130,7 +130,7 @@ const CandidatePreview = () => {
         h="1.75rem"
         mr="0.3rem"
         size="sm"
-        onClick={() => setFinfo({ name: '', size: 0 })}
+        onClick={() => setFinfo({ name: '', size: 0, uploaded: false })}
       >
         Change
       </Button>


### PR DESCRIPTION
When users upload a contract for the first time, there are a few areas that could be improved for a better user experience:

1. After the upload is completed, the displayed message shows "Codehash already exists" instead of "Contract Uploaded successfully." This misleading message might make users think that the contract has been uploaded before.
2. After the upload is completed, the unnecessary query performed by uploadCodeCheckAtom causes the components to flicker intermittently.
3. When clicking the Change button, the area to upload the contract appears, but the Restore area does not disappear.