### PR TITLE
Fix crash issue caused by an invalid AccountId value

### DIFF
--- a/src/features/phat-contract/argumentsFormAtom.ts
+++ b/src/features/phat-contract/argumentsFormAtom.ts
@@ -7,7 +7,7 @@ import * as R from 'ramda'
 import { v4 } from 'uuid'
 import { TypeDef } from '@polkadot/types/types'
 import { atomWithReducer, waitForAll, atomFamily } from 'jotai/utils'
-import { subToArray, validateNotUndefined, validateSub } from '@/functions/argumentsValidator'
+import { subToArray, validateNotUndefined, validateSub, validatePlainType } from '@/functions/argumentsValidator'
 import { currentAbiAtom, currentMethodAtom } from './atoms'
 import BN from 'bn.js'
 import createLogger from '@/functions/createLogger'
@@ -570,6 +570,15 @@ export const getCheckedFieldData = (fieldData: FieldDataNormalized, isRendered: 
           checkedErrors = validateNotUndefined(nestValue)
         }
 
+        if (checkedErrors.length && !R.equals(errors, checkedErrors)) {
+          return R.assoc('errors', checkedErrors, fieldData)
+        }
+      } else if (info === TypeDefInfo.Plain) {
+        let checkedErrors = validateNotUndefined(value)
+        if (!checkedErrors.length) {
+          const value$1 = value as string
+          checkedErrors = validatePlainType(fieldData.typeDef, value).errors
+        }
         if (checkedErrors.length && !R.equals(errors, checkedErrors)) {
           return R.assoc('errors', checkedErrors, fieldData)
         }

--- a/src/features/phat-contract/components/contract-method-arguments-form.tsx
+++ b/src/features/phat-contract/components/contract-method-arguments-form.tsx
@@ -40,9 +40,11 @@ import * as R from 'ramda'
 import {
   isNumberLikeType,
   isBoolType,
+  isAddressType,
   subToArray,
   PlainType,
   validateNotUndefined,
+  validateAddress,
   convertToBN,
   cantToNumberMessage
 } from '@/functions/argumentsValidator'
@@ -511,7 +513,11 @@ const OtherTypeFieldData = ({ fieldData, dispatch }: EachFieldDataProps) => {
 
   console.log('OtherTypeFieldData render: fieldData', fieldData)
 
-  useEffect(() => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setInnerValue(event.target.value)
+  }
+
+  const handleBlur = () => {
     if (!innerValue) {
       dispatchValue(dispatch, uid, undefined)
     } else {
@@ -526,17 +532,14 @@ const OtherTypeFieldData = ({ fieldData, dispatch }: EachFieldDataProps) => {
           // noop
         }
       }
+      if (isAddressType(type as PlainType)) {
+        const { errors } = validateAddress(fieldData.typeDef, nextValue as string)
+        if (errors.length > 0) {
+          return dispatchErrors(dispatch, uid, errors)
+        }
+      }
       dispatchValue(dispatch, uid, nextValue)
     }
-  }, [innerValue])
-
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setInnerValue(event.target.value)
-  }
-
-  const handleBlur = () => {
-    const errors = validateNotUndefined(value)
-    dispatchErrors(dispatch, uid, errors)
   }
 
   return (

--- a/src/functions/argumentsValidator.ts
+++ b/src/functions/argumentsValidator.ts
@@ -3,6 +3,8 @@ import type { Abi } from '@polkadot/api-contract'
 import { AbiParam } from '@polkadot/api-contract/types'
 import { TypeDefInfo } from '@polkadot/types'
 import { TypeDef } from '@polkadot/types/types'
+import { decodeAddress, encodeAddress } from '@polkadot/keyring'
+import { hexToU8a, isHex } from '@polkadot/util'
 import { BN } from 'bn.js'
 import { z } from 'zod'
 import * as R from 'ramda'
@@ -342,6 +344,19 @@ export const validateBoolType = (_: TypeDef, inputValue: string | number) => {
   }
 }
 
+export const validateAddress = (_: TypeDef, inputValue: string) => {
+  try {
+    encodeAddress(
+      isHex(inputValue)
+        ? hexToU8a(inputValue)
+        : decodeAddress(inputValue)
+    )
+    return createValueInfo(inputValue)
+  } catch (error) {
+    return inputTypeInvalidMessage(inputValue, ['Address'])
+  }
+}
+
 // Plain type value's validation
 export const validatePlainType = (typeDef: TypeDef, inputValue: unknown): ValidateInfo<unknown> => {
   const { type } = typeDef
@@ -361,7 +376,9 @@ export const validatePlainType = (typeDef: TypeDef, inputValue: unknown): Valida
     return validateBoolType(typeDef, inputValue$1)
   }
 
-  // TODO: Balance, Address, AccountId
+  if (isAddressType(type as PlainType)) {
+    return validateAddress(typeDef, inputValue as string)
+  }
 
   // Other type receives a String value
   const value = toString(inputValue$1)


### PR DESCRIPTION
Validate the address type field to avoid a crash in estimateGas caused by dispatching a invalid value.